### PR TITLE
docs: adjust wording for question 15, include framework

### DIFF
--- a/questions-2024.md
+++ b/questions-2024.md
@@ -193,7 +193,7 @@ _[checkboxes]_
 - Not applicable
 - _Other [text input]_
 
-## 15. Which UI library are you using the most?
+## 15. Which UI library or framework are you using the most?
 _[radio]_
 
 - React


### PR DESCRIPTION
This may not be a necessary change, but I feel Angular, Svelte, and Vue are better categorized as frameworks, while React is a library.

We can also consider adding Remix, Solid, and Astro, but they are probably more aimed towards user interfaces instead of game dev. I can see the existing options being used in conjunction with web game dev.